### PR TITLE
#31 map scene persistence

### DIFF
--- a/TrainGame/Assets/EventChoiceButton.cs
+++ b/TrainGame/Assets/EventChoiceButton.cs
@@ -58,7 +58,7 @@ public class EventChoiceButton : MonoBehaviour
         {
             foreach (KeyValuePair<Resource.ResourceType, int> kvp in eventRewardData.Rewards)
             {
-                GameController.Instance.Data.AddResource(kvp.Key, kvp.Value);
+                InterSceneData.AddResource(kvp.Key, kvp.Value);
             }
         }
 

--- a/TrainGame/Assets/MapPlayerController.cs
+++ b/TrainGame/Assets/MapPlayerController.cs
@@ -21,7 +21,7 @@ public class MapPlayerController : MonoBehaviour
             MapGameController.Instance.travelling = true;
             if (transform.position == MapGameController.Instance.target.transform.position)
             {
-                MapGameController.Instance.target.travelled = true;
+                MapGameController.Instance.target.visited = true;
                 MapGameController.Instance.travelling = false;
                 MapGameController.Instance.target.DrawRoads();
             }

--- a/TrainGame/Assets/Prefabs/MapNode.prefab
+++ b/TrainGame/Assets/Prefabs/MapNode.prefab
@@ -99,9 +99,10 @@ MonoBehaviour:
   m_Name: 
   m_EditorClassIdentifier: 
   parents: []
-  children:
-  - {fileID: 0}
-  travelled: 1
+  children: []
+  visited: 0
+  looted: 0
+  index: 0
   lineMaterial: {fileID: 10306, guid: 0000000000000000f000000000000000, type: 0}
   SceneName: 
 --- !u!58 &1029707616634969503

--- a/TrainGame/Assets/Scenes/MapScene.unity
+++ b/TrainGame/Assets/Scenes/MapScene.unity
@@ -145,7 +145,7 @@ GameObject:
   - component: {fileID: 501833389}
   - component: {fileID: 501833388}
   m_Layer: 0
-  m_Name: GameObject
+  m_Name: Map Game Controller
   m_TagString: Untagged
   m_Icon: {fileID: 0}
   m_NavMeshLayer: 0
@@ -165,6 +165,7 @@ MonoBehaviour:
   m_EditorClassIdentifier: 
   target: {fileID: 1759477222}
   travelling: 0
+  NodePrefab: {fileID: 3293232732229755680, guid: 695a417d28126634ea613af5ae224cb1, type: 3}
 --- !u!4 &501833389
 Transform:
   m_ObjectHideFlags: 0
@@ -175,20 +176,25 @@ Transform:
   m_LocalRotation: {x: 0, y: 0, z: 0, w: 1}
   m_LocalPosition: {x: 2.0303912, y: 1.166919, z: -2.2685797}
   m_LocalScale: {x: 1, y: 1, z: 1}
-  m_Children: []
+  m_Children:
+  - {fileID: 1123796302}
   m_Father: {fileID: 0}
-  m_RootOrder: 7
+  m_RootOrder: 2
   m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
 --- !u!1001 &519217699
 PrefabInstance:
   m_ObjectHideFlags: 0
   serializedVersion: 2
   m_Modification:
-    m_TransformParent: {fileID: 0}
+    m_TransformParent: {fileID: 1123796302}
     m_Modifications:
     - target: {fileID: 1289099967326588046, guid: 695a417d28126634ea613af5ae224cb1, type: 3}
       propertyPath: m_Name
       value: MapNode (3)
+      objectReference: {fileID: 0}
+    - target: {fileID: 3293232732229755680, guid: 695a417d28126634ea613af5ae224cb1, type: 3}
+      propertyPath: index
+      value: -1
       objectReference: {fileID: 0}
     - target: {fileID: 3293232732229755680, guid: 695a417d28126634ea613af5ae224cb1, type: 3}
       propertyPath: travelled
@@ -208,19 +214,19 @@ PrefabInstance:
       objectReference: {fileID: 2137535232}
     - target: {fileID: 4772735660737851438, guid: 695a417d28126634ea613af5ae224cb1, type: 3}
       propertyPath: m_RootOrder
-      value: 5
+      value: 3
       objectReference: {fileID: 0}
     - target: {fileID: 4772735660737851438, guid: 695a417d28126634ea613af5ae224cb1, type: 3}
       propertyPath: m_LocalPosition.x
-      value: 5.28
+      value: -2.7479815
       objectReference: {fileID: 0}
     - target: {fileID: 4772735660737851438, guid: 695a417d28126634ea613af5ae224cb1, type: 3}
       propertyPath: m_LocalPosition.y
-      value: -3.66
+      value: -3.816586
       objectReference: {fileID: 0}
     - target: {fileID: 4772735660737851438, guid: 695a417d28126634ea613af5ae224cb1, type: 3}
       propertyPath: m_LocalPosition.z
-      value: 0
+      value: 4.2337255
       objectReference: {fileID: 0}
     - target: {fileID: 4772735660737851438, guid: 695a417d28126634ea613af5ae224cb1, type: 3}
       propertyPath: m_LocalRotation.w
@@ -228,15 +234,15 @@ PrefabInstance:
       objectReference: {fileID: 0}
     - target: {fileID: 4772735660737851438, guid: 695a417d28126634ea613af5ae224cb1, type: 3}
       propertyPath: m_LocalRotation.x
-      value: 0
+      value: -0
       objectReference: {fileID: 0}
     - target: {fileID: 4772735660737851438, guid: 695a417d28126634ea613af5ae224cb1, type: 3}
       propertyPath: m_LocalRotation.y
-      value: 0
+      value: -0
       objectReference: {fileID: 0}
     - target: {fileID: 4772735660737851438, guid: 695a417d28126634ea613af5ae224cb1, type: 3}
       propertyPath: m_LocalRotation.z
-      value: 0
+      value: -0
       objectReference: {fileID: 0}
     - target: {fileID: 4772735660737851438, guid: 695a417d28126634ea613af5ae224cb1, type: 3}
       propertyPath: m_LocalEulerAnglesHint.x
@@ -252,6 +258,11 @@ PrefabInstance:
       objectReference: {fileID: 0}
     m_RemovedComponents: []
   m_SourcePrefab: {fileID: 100100000, guid: 695a417d28126634ea613af5ae224cb1, type: 3}
+--- !u!4 &519217700 stripped
+Transform:
+  m_CorrespondingSourceObject: {fileID: 4772735660737851438, guid: 695a417d28126634ea613af5ae224cb1, type: 3}
+  m_PrefabInstance: {fileID: 519217699}
+  m_PrefabAsset: {fileID: 0}
 --- !u!114 &544916774 stripped
 MonoBehaviour:
   m_CorrespondingSourceObject: {fileID: 3293232732229755680, guid: 695a417d28126634ea613af5ae224cb1, type: 3}
@@ -268,11 +279,15 @@ PrefabInstance:
   m_ObjectHideFlags: 0
   serializedVersion: 2
   m_Modification:
-    m_TransformParent: {fileID: 0}
+    m_TransformParent: {fileID: 1123796302}
     m_Modifications:
     - target: {fileID: 1289099967326588046, guid: 695a417d28126634ea613af5ae224cb1, type: 3}
       propertyPath: m_Name
       value: MapNode (2)
+      objectReference: {fileID: 0}
+    - target: {fileID: 3293232732229755680, guid: 695a417d28126634ea613af5ae224cb1, type: 3}
+      propertyPath: index
+      value: -1
       objectReference: {fileID: 0}
     - target: {fileID: 3293232732229755680, guid: 695a417d28126634ea613af5ae224cb1, type: 3}
       propertyPath: travelled
@@ -288,19 +303,19 @@ PrefabInstance:
       objectReference: {fileID: 0}
     - target: {fileID: 4772735660737851438, guid: 695a417d28126634ea613af5ae224cb1, type: 3}
       propertyPath: m_RootOrder
-      value: 4
+      value: 2
       objectReference: {fileID: 0}
     - target: {fileID: 4772735660737851438, guid: 695a417d28126634ea613af5ae224cb1, type: 3}
       propertyPath: m_LocalPosition.x
-      value: 7.99
+      value: -0.037981987
       objectReference: {fileID: 0}
     - target: {fileID: 4772735660737851438, guid: 695a417d28126634ea613af5ae224cb1, type: 3}
       propertyPath: m_LocalPosition.y
-      value: -1.85
+      value: -2.006586
       objectReference: {fileID: 0}
     - target: {fileID: 4772735660737851438, guid: 695a417d28126634ea613af5ae224cb1, type: 3}
       propertyPath: m_LocalPosition.z
-      value: 0
+      value: 4.2337255
       objectReference: {fileID: 0}
     - target: {fileID: 4772735660737851438, guid: 695a417d28126634ea613af5ae224cb1, type: 3}
       propertyPath: m_LocalRotation.w
@@ -308,15 +323,15 @@ PrefabInstance:
       objectReference: {fileID: 0}
     - target: {fileID: 4772735660737851438, guid: 695a417d28126634ea613af5ae224cb1, type: 3}
       propertyPath: m_LocalRotation.x
-      value: 0
+      value: -0
       objectReference: {fileID: 0}
     - target: {fileID: 4772735660737851438, guid: 695a417d28126634ea613af5ae224cb1, type: 3}
       propertyPath: m_LocalRotation.y
-      value: 0
+      value: -0
       objectReference: {fileID: 0}
     - target: {fileID: 4772735660737851438, guid: 695a417d28126634ea613af5ae224cb1, type: 3}
       propertyPath: m_LocalRotation.z
-      value: 0
+      value: -0
       objectReference: {fileID: 0}
     - target: {fileID: 4772735660737851438, guid: 695a417d28126634ea613af5ae224cb1, type: 3}
       propertyPath: m_LocalEulerAnglesHint.x
@@ -332,6 +347,11 @@ PrefabInstance:
       objectReference: {fileID: 0}
     m_RemovedComponents: []
   m_SourcePrefab: {fileID: 100100000, guid: 695a417d28126634ea613af5ae224cb1, type: 3}
+--- !u!4 &546003816 stripped
+Transform:
+  m_CorrespondingSourceObject: {fileID: 4772735660737851438, guid: 695a417d28126634ea613af5ae224cb1, type: 3}
+  m_PrefabInstance: {fileID: 546003815}
+  m_PrefabAsset: {fileID: 0}
 --- !u!114 &549978532 stripped
 MonoBehaviour:
   m_CorrespondingSourceObject: {fileID: 3293232732229755680, guid: 695a417d28126634ea613af5ae224cb1, type: 3}
@@ -440,6 +460,42 @@ MonoBehaviour:
   m_Name: 
   m_EditorClassIdentifier: 
   Speed: 1
+--- !u!1 &1123796301
+GameObject:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  serializedVersion: 6
+  m_Component:
+  - component: {fileID: 1123796302}
+  m_Layer: 0
+  m_Name: Nodes
+  m_TagString: Untagged
+  m_Icon: {fileID: 0}
+  m_NavMeshLayer: 0
+  m_StaticEditorFlags: 0
+  m_IsActive: 1
+--- !u!4 &1123796302
+Transform:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 1123796301}
+  m_LocalRotation: {x: -0, y: -0, z: -0, w: 1}
+  m_LocalPosition: {x: 5.9975905, y: -1.0103331, z: -1.9651458}
+  m_LocalScale: {x: 1, y: 1, z: 1}
+  m_Children:
+  - {fileID: 2409121229746774235}
+  - {fileID: 1540518604}
+  - {fileID: 546003816}
+  - {fileID: 519217700}
+  - {fileID: 1856584605}
+  - {fileID: 2137535233}
+  m_Father: {fileID: 501833389}
+  m_RootOrder: 0
+  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
 --- !u!1 &1503390080
 GameObject:
   m_ObjectHideFlags: 0
@@ -451,6 +507,7 @@ GameObject:
   - component: {fileID: 1503390083}
   - component: {fileID: 1503390082}
   - component: {fileID: 1503390081}
+  - component: {fileID: 1503390084}
   m_Layer: 0
   m_Name: Main Camera
   m_TagString: MainCamera
@@ -523,16 +580,40 @@ Transform:
   m_Father: {fileID: 0}
   m_RootOrder: 0
   m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
+--- !u!114 &1503390084
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 1503390080}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: 03a01c1afc6c6314d97a3edd72a29c9c, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+  X: 1
+  Y: 1
+  Z: 0
+  target: {fileID: 855761669}
 --- !u!1001 &1540518603
 PrefabInstance:
   m_ObjectHideFlags: 0
   serializedVersion: 2
   m_Modification:
-    m_TransformParent: {fileID: 0}
+    m_TransformParent: {fileID: 1123796302}
     m_Modifications:
     - target: {fileID: 1289099967326588046, guid: 695a417d28126634ea613af5ae224cb1, type: 3}
       propertyPath: m_Name
       value: MapNode (1)
+      objectReference: {fileID: 0}
+    - target: {fileID: 3293232732229755680, guid: 695a417d28126634ea613af5ae224cb1, type: 3}
+      propertyPath: index
+      value: -1
+      objectReference: {fileID: 0}
+    - target: {fileID: 3293232732229755680, guid: 695a417d28126634ea613af5ae224cb1, type: 3}
+      propertyPath: SceneName
+      value: 
       objectReference: {fileID: 0}
     - target: {fileID: 3293232732229755680, guid: 695a417d28126634ea613af5ae224cb1, type: 3}
       propertyPath: travelled
@@ -560,19 +641,19 @@ PrefabInstance:
       objectReference: {fileID: 1766261423}
     - target: {fileID: 4772735660737851438, guid: 695a417d28126634ea613af5ae224cb1, type: 3}
       propertyPath: m_RootOrder
-      value: 3
+      value: 1
       objectReference: {fileID: 0}
     - target: {fileID: 4772735660737851438, guid: 695a417d28126634ea613af5ae224cb1, type: 3}
       propertyPath: m_LocalPosition.x
-      value: 0.08
+      value: -7.947982
       objectReference: {fileID: 0}
     - target: {fileID: 4772735660737851438, guid: 695a417d28126634ea613af5ae224cb1, type: 3}
       propertyPath: m_LocalPosition.y
-      value: -2.28
+      value: -2.436586
       objectReference: {fileID: 0}
     - target: {fileID: 4772735660737851438, guid: 695a417d28126634ea613af5ae224cb1, type: 3}
       propertyPath: m_LocalPosition.z
-      value: 0
+      value: 4.2337255
       objectReference: {fileID: 0}
     - target: {fileID: 4772735660737851438, guid: 695a417d28126634ea613af5ae224cb1, type: 3}
       propertyPath: m_LocalRotation.w
@@ -580,15 +661,15 @@ PrefabInstance:
       objectReference: {fileID: 0}
     - target: {fileID: 4772735660737851438, guid: 695a417d28126634ea613af5ae224cb1, type: 3}
       propertyPath: m_LocalRotation.x
-      value: 0
+      value: -0
       objectReference: {fileID: 0}
     - target: {fileID: 4772735660737851438, guid: 695a417d28126634ea613af5ae224cb1, type: 3}
       propertyPath: m_LocalRotation.y
-      value: 0
+      value: -0
       objectReference: {fileID: 0}
     - target: {fileID: 4772735660737851438, guid: 695a417d28126634ea613af5ae224cb1, type: 3}
       propertyPath: m_LocalRotation.z
-      value: 0
+      value: -0
       objectReference: {fileID: 0}
     - target: {fileID: 4772735660737851438, guid: 695a417d28126634ea613af5ae224cb1, type: 3}
       propertyPath: m_LocalEulerAnglesHint.x
@@ -604,6 +685,11 @@ PrefabInstance:
       objectReference: {fileID: 0}
     m_RemovedComponents: []
   m_SourcePrefab: {fileID: 100100000, guid: 695a417d28126634ea613af5ae224cb1, type: 3}
+--- !u!4 &1540518604 stripped
+Transform:
+  m_CorrespondingSourceObject: {fileID: 4772735660737851438, guid: 695a417d28126634ea613af5ae224cb1, type: 3}
+  m_PrefabInstance: {fileID: 1540518603}
+  m_PrefabAsset: {fileID: 0}
 --- !u!114 &1759477222 stripped
 MonoBehaviour:
   m_CorrespondingSourceObject: {fileID: 3293232732229755680, guid: 695a417d28126634ea613af5ae224cb1, type: 3}
@@ -631,11 +717,15 @@ PrefabInstance:
   m_ObjectHideFlags: 0
   serializedVersion: 2
   m_Modification:
-    m_TransformParent: {fileID: 0}
+    m_TransformParent: {fileID: 1123796302}
     m_Modifications:
     - target: {fileID: 1289099967326588046, guid: 695a417d28126634ea613af5ae224cb1, type: 3}
       propertyPath: m_Name
       value: MapNode (4)
+      objectReference: {fileID: 0}
+    - target: {fileID: 3293232732229755680, guid: 695a417d28126634ea613af5ae224cb1, type: 3}
+      propertyPath: index
+      value: -1
       objectReference: {fileID: 0}
     - target: {fileID: 3293232732229755680, guid: 695a417d28126634ea613af5ae224cb1, type: 3}
       propertyPath: travelled
@@ -651,19 +741,19 @@ PrefabInstance:
       objectReference: {fileID: 0}
     - target: {fileID: 4772735660737851438, guid: 695a417d28126634ea613af5ae224cb1, type: 3}
       propertyPath: m_RootOrder
-      value: 6
+      value: 4
       objectReference: {fileID: 0}
     - target: {fileID: 4772735660737851438, guid: 695a417d28126634ea613af5ae224cb1, type: 3}
       propertyPath: m_LocalPosition.x
-      value: 3.43
+      value: -4.5979815
       objectReference: {fileID: 0}
     - target: {fileID: 4772735660737851438, guid: 695a417d28126634ea613af5ae224cb1, type: 3}
       propertyPath: m_LocalPosition.y
-      value: -0.62
+      value: -0.776586
       objectReference: {fileID: 0}
     - target: {fileID: 4772735660737851438, guid: 695a417d28126634ea613af5ae224cb1, type: 3}
       propertyPath: m_LocalPosition.z
-      value: 0
+      value: 4.2337255
       objectReference: {fileID: 0}
     - target: {fileID: 4772735660737851438, guid: 695a417d28126634ea613af5ae224cb1, type: 3}
       propertyPath: m_LocalRotation.w
@@ -671,15 +761,15 @@ PrefabInstance:
       objectReference: {fileID: 0}
     - target: {fileID: 4772735660737851438, guid: 695a417d28126634ea613af5ae224cb1, type: 3}
       propertyPath: m_LocalRotation.x
-      value: 0
+      value: -0
       objectReference: {fileID: 0}
     - target: {fileID: 4772735660737851438, guid: 695a417d28126634ea613af5ae224cb1, type: 3}
       propertyPath: m_LocalRotation.y
-      value: 0
+      value: -0
       objectReference: {fileID: 0}
     - target: {fileID: 4772735660737851438, guid: 695a417d28126634ea613af5ae224cb1, type: 3}
       propertyPath: m_LocalRotation.z
-      value: 0
+      value: -0
       objectReference: {fileID: 0}
     - target: {fileID: 4772735660737851438, guid: 695a417d28126634ea613af5ae224cb1, type: 3}
       propertyPath: m_LocalEulerAnglesHint.x
@@ -695,6 +785,11 @@ PrefabInstance:
       objectReference: {fileID: 0}
     m_RemovedComponents: []
   m_SourcePrefab: {fileID: 100100000, guid: 695a417d28126634ea613af5ae224cb1, type: 3}
+--- !u!4 &1856584605 stripped
+Transform:
+  m_CorrespondingSourceObject: {fileID: 4772735660737851438, guid: 695a417d28126634ea613af5ae224cb1, type: 3}
+  m_PrefabInstance: {fileID: 1856584604}
+  m_PrefabAsset: {fileID: 0}
 --- !u!1 &1890282139
 GameObject:
   m_ObjectHideFlags: 0
@@ -759,18 +854,22 @@ Transform:
   m_LocalScale: {x: 1, y: 1, z: 1}
   m_Children: []
   m_Father: {fileID: 0}
-  m_RootOrder: 8
+  m_RootOrder: 3
   m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
 --- !u!1001 &2137535231
 PrefabInstance:
   m_ObjectHideFlags: 0
   serializedVersion: 2
   m_Modification:
-    m_TransformParent: {fileID: 0}
+    m_TransformParent: {fileID: 1123796302}
     m_Modifications:
     - target: {fileID: 1289099967326588046, guid: 695a417d28126634ea613af5ae224cb1, type: 3}
       propertyPath: m_Name
       value: MapNode (5)
+      objectReference: {fileID: 0}
+    - target: {fileID: 3293232732229755680, guid: 695a417d28126634ea613af5ae224cb1, type: 3}
+      propertyPath: index
+      value: -1
       objectReference: {fileID: 0}
     - target: {fileID: 3293232732229755680, guid: 695a417d28126634ea613af5ae224cb1, type: 3}
       propertyPath: travelled
@@ -786,19 +885,19 @@ PrefabInstance:
       objectReference: {fileID: 0}
     - target: {fileID: 4772735660737851438, guid: 695a417d28126634ea613af5ae224cb1, type: 3}
       propertyPath: m_RootOrder
-      value: 9
+      value: 5
       objectReference: {fileID: 0}
     - target: {fileID: 4772735660737851438, guid: 695a417d28126634ea613af5ae224cb1, type: 3}
       propertyPath: m_LocalPosition.x
-      value: 10.23
+      value: 2.2020178
       objectReference: {fileID: 0}
     - target: {fileID: 4772735660737851438, guid: 695a417d28126634ea613af5ae224cb1, type: 3}
       propertyPath: m_LocalPosition.y
-      value: -6.13
+      value: -6.2865863
       objectReference: {fileID: 0}
     - target: {fileID: 4772735660737851438, guid: 695a417d28126634ea613af5ae224cb1, type: 3}
       propertyPath: m_LocalPosition.z
-      value: 0
+      value: 4.2337255
       objectReference: {fileID: 0}
     - target: {fileID: 4772735660737851438, guid: 695a417d28126634ea613af5ae224cb1, type: 3}
       propertyPath: m_LocalRotation.w
@@ -806,15 +905,15 @@ PrefabInstance:
       objectReference: {fileID: 0}
     - target: {fileID: 4772735660737851438, guid: 695a417d28126634ea613af5ae224cb1, type: 3}
       propertyPath: m_LocalRotation.x
-      value: 0
+      value: -0
       objectReference: {fileID: 0}
     - target: {fileID: 4772735660737851438, guid: 695a417d28126634ea613af5ae224cb1, type: 3}
       propertyPath: m_LocalRotation.y
-      value: 0
+      value: -0
       objectReference: {fileID: 0}
     - target: {fileID: 4772735660737851438, guid: 695a417d28126634ea613af5ae224cb1, type: 3}
       propertyPath: m_LocalRotation.z
-      value: 0
+      value: -0
       objectReference: {fileID: 0}
     - target: {fileID: 4772735660737851438, guid: 695a417d28126634ea613af5ae224cb1, type: 3}
       propertyPath: m_LocalEulerAnglesHint.x
@@ -841,16 +940,29 @@ MonoBehaviour:
   m_Script: {fileID: 11500000, guid: 544f0a5cf0c276b45a4ea09a3a696ccb, type: 3}
   m_Name: 
   m_EditorClassIdentifier: 
+--- !u!4 &2137535233 stripped
+Transform:
+  m_CorrespondingSourceObject: {fileID: 4772735660737851438, guid: 695a417d28126634ea613af5ae224cb1, type: 3}
+  m_PrefabInstance: {fileID: 2137535231}
+  m_PrefabAsset: {fileID: 0}
 --- !u!1001 &2409121229746774234
 PrefabInstance:
   m_ObjectHideFlags: 0
   serializedVersion: 2
   m_Modification:
-    m_TransformParent: {fileID: 0}
+    m_TransformParent: {fileID: 1123796302}
     m_Modifications:
     - target: {fileID: 1289099967326588046, guid: 695a417d28126634ea613af5ae224cb1, type: 3}
       propertyPath: m_Name
       value: MapNode
+      objectReference: {fileID: 0}
+    - target: {fileID: 3293232732229755680, guid: 695a417d28126634ea613af5ae224cb1, type: 3}
+      propertyPath: index
+      value: -1
+      objectReference: {fileID: 0}
+    - target: {fileID: 3293232732229755680, guid: 695a417d28126634ea613af5ae224cb1, type: 3}
+      propertyPath: children.Array.size
+      value: 1
       objectReference: {fileID: 0}
     - target: {fileID: 3293232732229755680, guid: 695a417d28126634ea613af5ae224cb1, type: 3}
       propertyPath: children.Array.data[0]
@@ -858,19 +970,19 @@ PrefabInstance:
       objectReference: {fileID: 549978532}
     - target: {fileID: 4772735660737851438, guid: 695a417d28126634ea613af5ae224cb1, type: 3}
       propertyPath: m_RootOrder
-      value: 2
+      value: 0
       objectReference: {fileID: 0}
     - target: {fileID: 4772735660737851438, guid: 695a417d28126634ea613af5ae224cb1, type: 3}
       propertyPath: m_LocalPosition.x
-      value: -4.57
+      value: -12.597982
       objectReference: {fileID: 0}
     - target: {fileID: 4772735660737851438, guid: 695a417d28126634ea613af5ae224cb1, type: 3}
       propertyPath: m_LocalPosition.y
-      value: -0.04
+      value: -0.19658598
       objectReference: {fileID: 0}
     - target: {fileID: 4772735660737851438, guid: 695a417d28126634ea613af5ae224cb1, type: 3}
       propertyPath: m_LocalPosition.z
-      value: 0
+      value: 4.2337255
       objectReference: {fileID: 0}
     - target: {fileID: 4772735660737851438, guid: 695a417d28126634ea613af5ae224cb1, type: 3}
       propertyPath: m_LocalRotation.w
@@ -878,15 +990,15 @@ PrefabInstance:
       objectReference: {fileID: 0}
     - target: {fileID: 4772735660737851438, guid: 695a417d28126634ea613af5ae224cb1, type: 3}
       propertyPath: m_LocalRotation.x
-      value: 0
+      value: -0
       objectReference: {fileID: 0}
     - target: {fileID: 4772735660737851438, guid: 695a417d28126634ea613af5ae224cb1, type: 3}
       propertyPath: m_LocalRotation.y
-      value: 0
+      value: -0
       objectReference: {fileID: 0}
     - target: {fileID: 4772735660737851438, guid: 695a417d28126634ea613af5ae224cb1, type: 3}
       propertyPath: m_LocalRotation.z
-      value: 0
+      value: -0
       objectReference: {fileID: 0}
     - target: {fileID: 4772735660737851438, guid: 695a417d28126634ea613af5ae224cb1, type: 3}
       propertyPath: m_LocalEulerAnglesHint.x
@@ -906,3 +1018,8 @@ PrefabInstance:
       objectReference: {fileID: 0}
     m_RemovedComponents: []
   m_SourcePrefab: {fileID: 100100000, guid: 695a417d28126634ea613af5ae224cb1, type: 3}
+--- !u!4 &2409121229746774235 stripped
+Transform:
+  m_CorrespondingSourceObject: {fileID: 4772735660737851438, guid: 695a417d28126634ea613af5ae224cb1, type: 3}
+  m_PrefabInstance: {fileID: 2409121229746774234}
+  m_PrefabAsset: {fileID: 0}

--- a/TrainGame/Assets/Scripts/Data.meta
+++ b/TrainGame/Assets/Scripts/Data.meta
@@ -1,0 +1,8 @@
+fileFormatVersion: 2
+guid: f34e64c7298f1a14e809acf71e93ba8f
+folderAsset: yes
+DefaultImporter:
+  externalObjects: {}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/TrainGame/Assets/Scripts/Data/InterSceneData.cs
+++ b/TrainGame/Assets/Scripts/Data/InterSceneData.cs
@@ -3,13 +3,17 @@ using System.Collections;
 using System.Collections.Generic;
 using UnityEngine;
 
-public class GameData
+public static class InterSceneData
 {
     //Resources
-    public event Action<Resource.ResourceType, int> OnResourceChange;
+    public static event Action<Resource.ResourceType, int> OnResourceChange;
+    //Map Data
+    public static MapData Map;
 
-    Dictionary<Resource.ResourceType, int> Resources = new Dictionary<Resource.ResourceType, int>();
-    public void AddResource(Resource.ResourceType type, int amount)
+    static Dictionary<Resource.ResourceType, int> Resources = new Dictionary<Resource.ResourceType, int>();
+
+
+    public static void AddResource(Resource.ResourceType type, int amount)
     {
         if (Resources.ContainsKey(type))
         {
@@ -23,7 +27,7 @@ public class GameData
         }
     }
 
-    public int GetResource(Resource.ResourceType type)
+    public static int GetResource(Resource.ResourceType type)
     {
         if (!Resources.ContainsKey(type))
             return 0;

--- a/TrainGame/Assets/Scripts/Data/InterSceneData.cs.meta
+++ b/TrainGame/Assets/Scripts/Data/InterSceneData.cs.meta
@@ -1,5 +1,5 @@
 fileFormatVersion: 2
-guid: 21c4f96135dedd843888fabfa3080cfc
+guid: 8b3fa4fc5cc1a034a8c60855e18dfc68
 MonoImporter:
   externalObjects: {}
   serializedVersion: 2

--- a/TrainGame/Assets/Scripts/Data/MapData.cs
+++ b/TrainGame/Assets/Scripts/Data/MapData.cs
@@ -1,0 +1,22 @@
+using System;
+using System.Collections;
+using System.Collections.Generic;
+using UnityEngine;
+
+[Serializable]
+public class MapData
+{
+    public Vector3 PlayerPosition;
+    public int target;
+    public List<MapNodeData> Nodes;
+}
+
+[Serializable]
+public struct MapNodeData
+{
+    public int index;
+    public Vector3 position;
+    public bool visited;
+    public bool looted;
+    public List<int> children;
+}

--- a/TrainGame/Assets/Scripts/Data/MapData.cs.meta
+++ b/TrainGame/Assets/Scripts/Data/MapData.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: cc03b0d5cc8b2b8429e7c1fc38bd11d6
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/TrainGame/Assets/Scripts/Data/SaveDataController.cs
+++ b/TrainGame/Assets/Scripts/Data/SaveDataController.cs
@@ -1,0 +1,18 @@
+using System.Collections;
+using System.Collections.Generic;
+using UnityEngine;
+
+public class SaveDataController : MonoBehaviour
+{
+    // Start is called before the first frame update
+    void Start()
+    {
+        
+    }
+
+    // Update is called once per frame
+    void Update()
+    {
+        
+    }
+}

--- a/TrainGame/Assets/Scripts/Data/SaveDataController.cs
+++ b/TrainGame/Assets/Scripts/Data/SaveDataController.cs
@@ -1,18 +1,21 @@
 using System.Collections;
 using System.Collections.Generic;
+using System.IO;
 using UnityEngine;
 
-public class SaveDataController : MonoBehaviour
+public static class SaveDataController
 {
-    // Start is called before the first frame update
-    void Start()
+    public static void SaveRun()
     {
-        
+        string savefile = "";
+        savefile += JsonUtility.ToJson(InterSceneData.Map);
+        File.WriteAllText(Application.persistentDataPath + "/CurrentRun.dat", savefile);
     }
 
-    // Update is called once per frame
-    void Update()
+    public static void LoadRun()
     {
-        
+        string savefile = File.ReadAllText(Application.persistentDataPath + "/CurrentRun.dat");
+        MapData map = JsonUtility.FromJson<MapData>(savefile);
+        InterSceneData.Map = map;
     }
 }

--- a/TrainGame/Assets/Scripts/Data/SaveDataController.cs.meta
+++ b/TrainGame/Assets/Scripts/Data/SaveDataController.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: 3327b6454b7847843b550e7e1abd924f
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/TrainGame/Assets/Scripts/Follows.cs
+++ b/TrainGame/Assets/Scripts/Follows.cs
@@ -1,0 +1,15 @@
+using System.Collections;
+using System.Collections.Generic;
+using UnityEngine;
+
+public class Follows : MonoBehaviour
+{
+    public bool X, Y, Z;
+    public Transform target;
+
+    // Update is called once per frame
+    void Update()
+    {
+        transform.position = new Vector3(X ? target.position.x : transform.position.x, Y ? target.position.y : transform.position.y, Z ? target.position.z : transform.position.z);
+    }
+}

--- a/TrainGame/Assets/Scripts/Follows.cs.meta
+++ b/TrainGame/Assets/Scripts/Follows.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: 03a01c1afc6c6314d97a3edd72a29c9c
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/TrainGame/Assets/Scripts/GameController.cs
+++ b/TrainGame/Assets/Scripts/GameController.cs
@@ -10,8 +10,6 @@ public class GameController : UnitySingleton<GameController>
 
     public TrainController Train;
 
-    public GameData Data = new GameData();
-
     public GameObject EventPopupPrefab, EventPopupGO;
 
     void Start()

--- a/TrainGame/Assets/Scripts/MapGameController.cs
+++ b/TrainGame/Assets/Scripts/MapGameController.cs
@@ -58,7 +58,6 @@ public class MapGameController : UnitySingleton<MapGameController>
             MapNode node = nodes.Find((x) => x.index == data.index);
             for (int i = 0; i < data.children.Count; i++)
                 node.children.Add(nodes.Find((x) => x.index == data.children[i]));
-            //Debug.Log($"node {node.index} {node.children.Count}");
         }
     }
 

--- a/TrainGame/Assets/Scripts/MapGameController.cs
+++ b/TrainGame/Assets/Scripts/MapGameController.cs
@@ -6,21 +6,84 @@ public class MapGameController : UnitySingleton<MapGameController>
 {
     public MapNode target;
     public bool travelling;
+
+    [Header("Prefabs")]
+    [SerializeField]
+    public MapNode NodePrefab;
+
+    List<MapNode> nodes;
     MapPlayerController player;
     protected override void Awake()
     {
         base.Awake();
         player = FindObjectOfType<MapPlayerController>();
+
+        //If the game saved data from a previous visit on the map, update the map with the data
+        if (InterSceneData.Map != null)
+        {
+            Load();
+        }
+        else
+            nodes = new List<MapNode>(FindObjectsOfType<MapNode>());
     }
     // Start is called before the first frame update
     void Start()
     {
-        
+
     }
 
-    // Update is called once per frame
-    void Update()
+    public void Load()
     {
-        
+        foreach (Transform child in transform)
+        {
+            Destroy(child.gameObject);
+        }
+        nodes = new List<MapNode>();
+        //Set the player to the last known position
+        player.transform.position = InterSceneData.Map.PlayerPosition;
+        //Instantiate map nodes with the correct data
+        foreach (MapNodeData node in InterSceneData.Map.Nodes)
+        {
+            MapNode instance = Instantiate(NodePrefab, node.position, Quaternion.identity, transform);
+            nodes.Add(instance);
+            instance.index = node.index;
+            if (instance.index == InterSceneData.Map.target)
+                target = instance;
+            instance.visited = node.visited;
+            instance.looted = node.looted;
+        }
+        //Set children and parents relationships
+        foreach (MapNodeData data in InterSceneData.Map.Nodes)
+        {
+            MapNode node = nodes.Find((x) => x.index == data.index);
+            for (int i = 0; i < data.children.Count; i++)
+                node.children.Add(nodes.Find((x) => x.index == data.children[i]));
+            //Debug.Log($"node {node.index} {node.children.Count}");
+        }
+    }
+
+    public void Save()
+    {
+        List<MapNodeData> nodeData = new List<MapNodeData>();
+        foreach (MapNode node in nodes)
+        {
+            List<int> children = new List<int>();
+            foreach (MapNode child in node.children)
+                children.Add(child.index);
+            nodeData.Add(new MapNodeData
+            {
+                position = node.transform.position,
+                visited = node.visited,
+                looted = node.looted,
+                index = node.index,
+                children = children
+            });
+        }
+        InterSceneData.Map = new MapData
+        {
+            PlayerPosition = player.transform.position,
+            Nodes = nodeData,
+            target = target.index
+        };
     }
 }

--- a/TrainGame/Assets/Scripts/MapNode.cs
+++ b/TrainGame/Assets/Scripts/MapNode.cs
@@ -8,13 +8,18 @@ public class MapNode : MonoBehaviour
 {
     public List<MapNode> parents;
     public List<MapNode> children;
-    public bool travelled = false;
+    [HideInInspector]
+    public bool visited = false;
+    [HideInInspector]
+    public bool looted = false;
+    public int index = -1;
 
     [SerializeField]
     Material lineMaterial;
     [SerializeField]
     string SceneName;
 
+    static int nextNodeIndex = 0;
     Button button;
     private void Awake()
     {
@@ -23,7 +28,12 @@ public class MapNode : MonoBehaviour
     // Start is called before the first frame update
     void Start()
     {
-        if (travelled)
+        if(index == -1)
+        {
+            index = nextNodeIndex;
+            nextNodeIndex++;
+        }
+        if (visited)
             DrawRoads();
 
         for (int i = 0; i < children.Count; i++)
@@ -34,7 +44,6 @@ public class MapNode : MonoBehaviour
     {
         if(Input.GetKeyDown(KeyCode.Mouse0))
         {
-            Debug.Log("Boop");
             if (parents.Contains(MapGameController.Instance.target))
                 MapGameController.Instance.target = this;
         }
@@ -42,7 +51,7 @@ public class MapNode : MonoBehaviour
 
     private void Update()
     {
-        button.gameObject.SetActive(MapGameController.Instance.target == this && !MapGameController.Instance.travelling);
+        button.gameObject.SetActive(MapGameController.Instance.target == this && !MapGameController.Instance.travelling && !looted);
     }
 
     public void DrawRoads()
@@ -64,6 +73,8 @@ public class MapNode : MonoBehaviour
 
     public void SwitchScene()
     {
+        looted = true;
+        MapGameController.Instance.Save();
         SceneManager.LoadScene(SceneName);
     }
 

--- a/TrainGame/Assets/Scripts/ResourceUI.cs
+++ b/TrainGame/Assets/Scripts/ResourceUI.cs
@@ -36,11 +36,11 @@ public class ResourceUI : MonoBehaviour
     private void Start()
     {
         //Subscribe to the GameData event
-        GameController.Instance.Data.OnResourceChange += UpdateUI;
+        InterSceneData.OnResourceChange += UpdateUI;
         //Set initial values
         for (int i = 0; i < resourceSettings.Count; i++)
         {
-            UpdateUI(resourceSettings[i].Type, GameController.Instance.Data.GetResource(resourceSettings[i].Type));
+            UpdateUI(resourceSettings[i].Type, InterSceneData.GetResource(resourceSettings[i].Type));
         }
     }
 

--- a/TrainGame/Assets/Scripts/TrainResourceCollector.cs
+++ b/TrainGame/Assets/Scripts/TrainResourceCollector.cs
@@ -15,7 +15,7 @@ public class TrainResourceCollector : MonoBehaviour
         Resource resource = collision.gameObject.GetComponent<Resource>();
         if(resource != null)
         {
-            GameController.Instance.Data.AddResource(resource.type, resource.value);
+            InterSceneData.AddResource(resource.type, resource.value);
             resource.gameObject.GetComponent<Collider2D>().enabled = false;
             resource.gameObject.AddComponent<Shrink>().StartShrink(1);
             Rotate rotation = resource.gameObject.AddComponent<Rotate>();

--- a/TrainGame/Assets/TempEventPopupCreator.cs
+++ b/TrainGame/Assets/TempEventPopupCreator.cs
@@ -44,9 +44,9 @@ public class TempEventPopupCreator : MonoBehaviour
                         {
                             Rewards = new Dictionary<Resource.ResourceType, int>()
                             {
-                                { Resource.ResourceType.Ammunition, -GameController.Instance.Data.GetResource(Resource.ResourceType.Ammunition)},
-                                { Resource.ResourceType.Food, -GameController.Instance.Data.GetResource(Resource.ResourceType.Ammunition)},
-                                { Resource.ResourceType.Fuel, -GameController.Instance.Data.GetResource(Resource.ResourceType.Ammunition)},
+                                { Resource.ResourceType.Ammunition, -InterSceneData.GetResource(Resource.ResourceType.Ammunition)},
+                                { Resource.ResourceType.Food, -InterSceneData.GetResource(Resource.ResourceType.Ammunition)},
+                                { Resource.ResourceType.Fuel, -InterSceneData.GetResource(Resource.ResourceType.Ammunition)},
                             }
                         }
                     }
@@ -60,9 +60,9 @@ public class TempEventPopupCreator : MonoBehaviour
                         {
                             Rewards = new Dictionary<Resource.ResourceType, int>()
                             {
-                                { Resource.ResourceType.Ammunition, -GameController.Instance.Data.GetResource(Resource.ResourceType.Ammunition)/3},
-                                { Resource.ResourceType.Food, -GameController.Instance.Data.GetResource(Resource.ResourceType.Ammunition)/3},
-                                { Resource.ResourceType.Fuel, -GameController.Instance.Data.GetResource(Resource.ResourceType.Ammunition)/3},
+                                { Resource.ResourceType.Ammunition, -InterSceneData.GetResource(Resource.ResourceType.Ammunition)/3},
+                                { Resource.ResourceType.Food, -InterSceneData.GetResource(Resource.ResourceType.Ammunition)/3},
+                                { Resource.ResourceType.Fuel, -InterSceneData.GetResource(Resource.ResourceType.Ammunition)/3},
                             }
                         }
                     }


### PR DESCRIPTION
closes #31 
Move persistent game data to its own class.
The map scene reads data from persistent data if available, otherwise uses scene presets.
Map nodes can be looted, after which the option to return to their associated scene dissapears.
Add stub implementation of saving to disk.